### PR TITLE
Style the close button for easy spotting

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,11 @@ exports.decorateConfig = (config) => (
       .tab_text {
         border-color: transparent !important;
       }
+      /* Close button faint shadow for easy spotting */
+      .tab_icon {
+        background-color: rgba(255, 255, 255, .025);
+        opacity: 1;
+      }
     `
     })
 );


### PR DESCRIPTION
Hello @siamak, I love the work you have done with this Panda theme, is amazing.

For this PR I wanted to add a faint color over the close button on normal state so this can be easier to spot instead of having to move the mouse around trying to find it.

The color change is minimal but it helps the user to find the button, I hope you like it.

![panda](https://cloud.githubusercontent.com/assets/282903/18688207/4aa0f106-7f51-11e6-9192-ef35d337d8de.png)
